### PR TITLE
Adding white border to index's images & fixing logo path.

### DIFF
--- a/GridTest copy.html
+++ b/GridTest copy.html
@@ -10,7 +10,7 @@
         <!-- Background image -->
     </div>
     <div class="image-overlay">
-        <img src="/img/ue_logo.png" alt="Centered Image">
+        <img src="img/ue_logo.png" alt="Centered Image">
     </div>
 
 

--- a/css/main.css
+++ b/css/main.css
@@ -167,6 +167,10 @@ img{
     height: auto;
 }
 
+.image-border {
+    border-style: solid;
+}
+
 /*  --------------PAST PROJECTS-------------- */
 .PPV{
     text-align: center;

--- a/css/main.css
+++ b/css/main.css
@@ -167,7 +167,7 @@ img{
     height: auto;
 }
 
-.image-border {
+.image-border img {
     border-style: solid;
 }
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 			<!-- Background image -->
 		</div>
 		<div class="image-overlay">
-			<img src="/img/ue_logo.png" alt="Centered Image">
+			<img src="img/ue_logo.png" alt="Centered Image">
 		</div>
 
 				<div class="header">

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 			<div class="WholeBody">
 				<section>
 					<div class="container">
-						<div class="imageL">
+						<div class="imageL image-border"">
 							<img  src="img/FP_IMG/R1.png">
 						</div>
 
@@ -55,14 +55,14 @@
 							<h1>hello france man</h1>
 							<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Optio eos consequatur beatae odio iusto sint praesentium vel molestias quos dolor culpa, quisquam commodi labore ullam distinctio unde tenetur delectus aperiam?</p>
 						</div> 
-						<div class="imageR">
+						<div class="imageR image-border">
 							<img src="img/what.jpg">
 						</div>
 
 					</div>
 
 					<div class="container">
-						<div class="imageL">
+						<div class="imageL image-border">
 							<img src="img/what.jpg">
 						</div>
 

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
 			<div class="WholeBody">
 				<section>
 					<div class="container">
-						<div class="imageL image-border"">
-							<img  src="img/FP_IMG/R1.png">
+						<div class="imageL image-border">
+							<img src="img/FP_IMG/R1.png">
 						</div>
 
 						<div class="textL">


### PR DESCRIPTION
I've added the white borders to the images on the index page.

It uses the `image-border` class so if one image doesn't need a border it won't put one.